### PR TITLE
rename Integer::value/= method in C++ #121

### DIFF
--- a/ext/tatara/integer/integer.hpp
+++ b/ext/tatara/integer/integer.hpp
@@ -17,7 +17,7 @@ class Integer {
         std::string to_string();
         constexpr int plus_equal(int var);
         constexpr int minus_equal(int var);
-        constexpr int bracket_equal(int var);
+        constexpr int divided_equal(int var);
         constexpr int power_equal(int var);
         constexpr int clear();
         constexpr bool equal(const int var);
@@ -55,7 +55,7 @@ constexpr int Integer::minus_equal(int var) {
     return this->value -= var;
 }
 
-constexpr int Integer::bracket_equal(int var) {
+constexpr int Integer::divided_equal(int var) {
     return this->value /= var;
 }
 

--- a/ext/tatara/tatara.cpp
+++ b/ext/tatara/tatara.cpp
@@ -20,7 +20,7 @@ extern "C" {
             .define_method("value=", &Integer::assignment)
             .define_method("value+=", &Integer::plus_equal)
             .define_method("value-=", &Integer::minus_equal)
-            .define_method("value/=", &Integer::bracket_equal)
+            .define_method("value/=", &Integer::divided_equal)
             .define_method("value**=", &Integer::power_equal)
             .define_method("inc", &Integer::increment_value)
             .define_method("dec", &Integer::decrement_value)


### PR DESCRIPTION
Fix #121